### PR TITLE
Fix CachePool gc method

### DIFF
--- a/src/cache/cache-pool.js
+++ b/src/cache/cache-pool.js
@@ -20,7 +20,8 @@ const CacheItem = require('./cache-item.js');
  */
 class CachePool {
   constructor({
-    cacheSize=0
+    cacheSize=0,
+    chunkSize=0
   }={}) {
     const eof = new CacheItem({eof: true});
     this.head = eof;
@@ -30,6 +31,7 @@ class CachePool {
     this.writeOffset = 0;
     this.writeCursor = eof;
     this.cacheSize = cacheSize;
+    this.chunkSize = chunkSize;
   }
 
   /**

--- a/src/stream-file.js
+++ b/src/stream-file.js
@@ -51,6 +51,15 @@ class StreamFile {
         get: function() {
           return this.length === this._cache.readOffset;
         }
+      },
+
+      /**
+       * Max amount of data to keep buffered in memory for seeks
+       */
+      _chunkSize: {
+        get: function() {
+          return this._cache.chunkSize;
+        }
       }
     });
 
@@ -60,12 +69,12 @@ class StreamFile {
 
     // Private
     this._cache = new CachePool({
-      cacheSize
+      cacheSize,
+      chunkSize
     });
 
     this._backend = null;
     this._cachever = 0;
-    this._chunkSize = chunkSize;
   }
 
   /**


### PR DESCRIPTION
Add `chunkSize`  property in `CachePool` to fix `gc()` behavior.